### PR TITLE
email verified after Oauth verification

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -167,6 +167,8 @@ export class AuthService {
           isGoogleAuthUser: true,
         });
 
+        await this.emailVerificationService.markEmailAsConfirmed(newUser.email);
+
         let userProfile =
           await this.emailVerificationService.createGoogleUserProfile(newUser);
         const profileID = userProfile.data.id;
@@ -304,6 +306,7 @@ export class AuthService {
       isGoogleAuthUser: true,
     });
 
+    await this.emailVerificationService.markEmailAsConfirmed(newUser.email);
     let userProfile =
       await this.emailVerificationService.createGoogleUserProfile(newUser);
     const profileID = userProfile.data.id;

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -165,9 +165,9 @@ export class AuthService {
           email: email,
           fullName: name,
           isGoogleAuthUser: true,
+          isEmailVerified: true,
+          userOTP: null,
         });
-
-        await this.emailVerificationService.markEmailAsConfirmed(newUser.email);
 
         let userProfile =
           await this.emailVerificationService.createGoogleUserProfile(newUser);
@@ -304,9 +304,10 @@ export class AuthService {
       email: email,
       fullName: name,
       isGoogleAuthUser: true,
+      isEmailVerified: true,
+      userOTP: null,
     });
 
-    await this.emailVerificationService.markEmailAsConfirmed(newUser.email);
     let userProfile =
       await this.emailVerificationService.createGoogleUserProfile(newUser);
     const profileID = userProfile.data.id;


### PR DESCRIPTION
- OTP verification not necessary for Google users, since they are registering from a trusted source.

- Same goes for Github signup as well, the verified email address used on the github account was used to create an account.
